### PR TITLE
Added charset configuration with presets

### DIFF
--- a/font-src-sample/charset.config.json
+++ b/font-src-sample/charset.config.json
@@ -1,0 +1,4 @@
+ {
+    "charset": "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~’“”",
+    "presets": []
+ }

--- a/font-src-sample/charset.txt
+++ b/font-src-sample/charset.txt
@@ -1,1 +1,0 @@
- !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~’“”

--- a/src/genFont.ts
+++ b/src/genFont.ts
@@ -115,14 +115,12 @@ export async function genFont(fontFileName: string, fieldType: 'ssdf' | 'msdf'):
     const config:CharsetConfig =  JSON.parse(fs.readFileSync(charsetPath, 'utf8'))
     let charset = config.charset
     const presetsToApply = config.presets
-    if (presetsToApply.length > 0) {
-      for (let i = 0; i < presetsToApply.length; i++ ){
-        const key = presetsToApply[i]
-        if (key && key in presets)  {
-          charset += presets[key]
-        } else {
-          console.warn(`preset, '${key}' is not available in msdf-generator presets`)
-        }
+    for (let i = 0; i < presetsToApply.length; i++ ){
+      const key = presetsToApply[i]
+      if (key && key in presets)  {
+        charset += presets[key]
+      } else {
+        console.warn(`preset, '${key}' is not available in msdf-generator presets`)
       }
     }
     options['charset'] = charset

--- a/src/genFont.ts
+++ b/src/genFont.ts
@@ -30,12 +30,13 @@ let charsetPath = '';
  *
  * @param srcDir
  * @param dstDir
+ * @param charsetFilePath
  */
-export function setGeneratePaths(srcDir: string, dstDir: string) {
+export function setGeneratePaths(srcDir: string, dstDir: string, charsetFilePath?: string ) {
   fontSrcDir = srcDir;
   fontDstDir = dstDir;
   overridesPath = path.join(fontSrcDir, 'overrides.json');
-  charsetPath = path.join(fontSrcDir, 'charset.txt');
+  charsetPath = charsetFilePath ? charsetFilePath : path.join(fontSrcDir, 'charset.txt');
 }
 
 export interface SdfFontInfo {

--- a/src/presets.json
+++ b/src/presets.json
@@ -1,0 +1,5 @@
+{
+    "accents": "äöüßÄÖÜ",
+    "numeric": "",
+    "symbols": ""
+}

--- a/src/presets.json
+++ b/src/presets.json
@@ -1,5 +1,5 @@
 {
-    "accents": "äöüßÄÖÜ",
+    "accents": "",
     "numeric": "",
     "symbols": ""
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
   },
   "include": [
     "src/**/*",
-    "types/**/*"
+    "types/**/*",
+    "src/presets.json"
   ]
 }


### PR DESCRIPTION
1. Added charsetFilePath as an optional argument to setGeneratePaths function to support passing absolute path of charset file
2. Updated existing ```charset.txt``` format to ```charset.config.json``` with ```charset``` and ```presets``` as keys.
3. Added global presets.json file, this will be the single place of resourcse for all presets content.
