### PR TITLE
pin opentype.js dependency to 1.3.5 for to fix loadSync issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "chalk": "^5.3.0",
     "fs-extra": "^11.2.0",
     "msdf-bmfont-xml": "^2.8.0",
-    "opentype.js": "^1.3.4"
+    "opentype.js": "1.3.4"
   },
   "files": [
     "dist",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
         specifier: ^2.8.0
         version: 2.8.0
       opentype.js:
-        specifier: ^1.3.4
+        specifier: 1.3.4
         version: 1.3.4
     devDependencies:
       '@types/fs-extra':


### PR DESCRIPTION
Hi guys 👋

I created a new App and now seeing that it's failing on msdf font generation. After checking a bit, looks like this started after `opentype.js` released a new version recently

Since in package.json it is like `^1.3.4`, npm installs the newer version now, and there `loadSync()` function is changed. Because of that `msdf-bmfont-xml` package breaks with: `Cannot read properties of undefined (reading 'outlinesFormat')`

Pinning opentype.js to just `1.3.4` fixes the problem, since this is the last version where it still works fine

Thanks 🙏