### PR TITLE
Removes outdated baseline/y-offset correction in adjustFont

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+## 1.3.1
+
+- Fix: removed an outdated baseline/y-offset correction in `adjustFont.ts` that was misaligning generated fonts (affects fonts generated with v1.2.0 through v1.3.0).
+
+## 1.3.0
+
+- Multipage atlas generation fix
+- Added `textureSize` override
+
+## 1.2.1
+
+- Pinned `opentype.js` to `1.3.4` to fix a `loadSync` issue in newer versions
+
+## 1.2.0
+
+- Updated `msdf-bmfont-xml` to `^2.8.0`
+
+## 1.1.1
+
+- Made `presets` key optional in `<font>.config.json`
+
+## 1.1.0
+
+- Charset configuration with presets support
+
+## 1.0.2
+
+- Fixed header image URL in README for the npm page
+
+## 1.0.0
+
+- Initial npm publish, library exports added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightningjs/msdf-generator",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Converts font files (.ttf, .otf, .woff, .woff2) to SDF format for Lightning 3's renderer, with added font metrics generation for SDF and Canvas Web fonts",
   "type": "module",
   "exports": {

--- a/src/adjustFont.ts
+++ b/src/adjustFont.ts
@@ -24,15 +24,8 @@ import type { SdfFontInfo } from "./genFont.js";
 const metricsSubDir = 'metrics';
 
 /**
- * Adjusts the font data for the generated fonts.
- *
- * @remarks
- * A bug in the msdf-bmfont-xml package causes both the baseline and y-offsets
- * of every character to be incorrect which results in the text being rendered
- * out of intended alignment. This function corrects that data.
- *
- * See the following GitHub issue for more information:
- * https://github.com/soimy/msdf-bmfont-xml/pull/93
+ * Extracts font metrics from the source font and writes them into the
+ * generated JSON and a separate metrics file.
  *
  * @param fontInfo
  */
@@ -46,21 +39,6 @@ export async function adjustFont(fontInfo: SdfFontInfo) {
     opentype.load(fontInfo.fontPath),
   ]);
   const json = JSON.parse(jsonFileContents);
-  const distanceField = json.distanceField.distanceRange;
-  /**
-   * `pad` used by msdf-bmfont-xml
-   *
-   * (This is really just distanceField / 2 but guarantees a truncated integer result)
-   */
-  const pad = (distanceField >> 1);
-
-  // Remove 1x pad from the baseline
-  json.common.base = json.common.base - pad;
-
-  // Remove 2x pad from the y-offset of every character
-  for (const char of json.chars) {
-    char.yoffset = char.yoffset - pad - pad;
-  }
 
   const fontMetrics = {
     ascender: font.tables.os2!.sTypoAscender as number,


### PR DESCRIPTION
This fixes a silent but real bug affecting the vertical alignment of every font this tool has generated since October 2025 (`v1.2.0` through the current `v1.3.0`). Text is currently sitting slightly too low and this PR corrects it.

## Background

- [April 2024] : @frank-weindel noticed that `msdf-bmfont-xml` had a bug: it was placing the baseline and every character's vertical position slightly wrong. He added a small correction for it here, in `adjustFont.ts`. At the same time, he also opened this (https://github.com/soimy/msdf-bmfont-xml/pull/93) to fix the actual bug at its source.

He also added a `@remark` in the source code:

https://github.com/lightning-js/msdf-generator/blob/ae716ca1ee7c67ea6dea40fca77d02106100b234/src/adjustFont.ts#L30-L35

- [February 2025] : that upstream PR was merged. From this point on, any new version of `msdf-bmfont-xml` built from their `main` branch no longer has the bug.

- [October 2025] : [PR #14](https://github.com/lightning-js/msdf-generator/pull/14) updated our dependency to `msdf-bmfont-xml@2.8.0`, which includes that upstream fix. This was a good and necessary update. But after that point our own `adjustFont.ts` correction (written for the *old, broken* version) has started to double fix something that was already fixed.

## Changes

This PR removes the redundant correction in `adjustFont.ts`. The function still does its other job (extracting and writing font metrics), only the baseline/y-offset math is removed.

## Verification

1. Shows the baseline error with the old, unfixed `msdf-bmfont-xml`, before our `adjustFont.ts` correction is applied.
2. Shows what happens after applying our `adjustFont.ts` correction on top of that old, unfixed library.
3. Shows that the new `msdf-bmfont-xml` fixes the baseline issue on its own, without our correction.
4. The current shipped state, with the double correction applied.

So by removing the extra adjustment, we are returning to state 3. 

<img width="3416" height="2024" alt="baseline" src="https://github.com/user-attachments/assets/8a5d4544-9aaf-40cc-98fc-cdeac3e1a131" />

## Visual impact of this fix

**This fix will visibly shift text in every app that uses this package**, by a small amount (a couple of pixels based on the text configuration). It's not dramatic and that's exactly why this went unnoticed for months. But it is a real, visible change to existing layouts. Anyone relying on the current (incorrect) text position may notice things shift slightly, to the correct baseline. 